### PR TITLE
fix parsing of the map style for map styles with a dash in them

### DIFF
--- a/gopro_overlay/geo.py
+++ b/gopro_overlay/geo.py
@@ -38,7 +38,7 @@ def provider_for_style(name, api_key):
     if name == "osm":
         return geotiler.find_provider("osm")
     elif name.startswith("tf"):
-        style = name.split("-")[1]
+        style = name.split("-",1)[1]
         return MapProvider(thunderforest_attrs(style), api_key)
     else:
         raise KeyError(f"Unknown map provider: {name}")


### PR DESCRIPTION
Tiny fix to make map types with a dash in them parse correctly for the maps provider to get the correct URL.
Examples: tf-mobile-atlas, tf-transport-dark, and tf-spinal-map