### PR TITLE
Add XML option to turn of moving map rotation

### DIFF
--- a/build-scripts/examples/05-moving-map.md
+++ b/build-scripts/examples/05-moving-map.md
@@ -52,6 +52,12 @@ if `corner_radius` == half the width (ie. the radius) then the corners will be s
 
 {{ <component type="moving_map" size="256" corner_radius="128" zoom="8" /> }}
 
+## Map Rotation
+
+Map rotation can be turned off with `rotate`.
+
+{{ <component type="moving_map" size="256" rotate="False" /> }}
+
 ## Map Provider & Styles
 
 The map provider, and the map style, can be selected using the command line arguments when running the dashboard program. 

--- a/gopro_overlay/layout_xml.py
+++ b/gopro_overlay/layout_xml.py
@@ -265,7 +265,8 @@ def create_moving_map(element, entry, renderer, **kwargs):
         zoom=iattrib(element, "zoom", d=16, r=range(1, 18)),
         renderer=renderer,
         corner_radius=iattrib(element, "corner_radius", 0),
-        opacity=fattrib(element, "opacity", 0.7)
+        opacity=fattrib(element, "opacity", 0.7),
+        rotate=battrib(element, "rotate", d=True)
     )
 
 


### PR DESCRIPTION
Adds a boolean option `rotate` to `moving_map` components in XML layouts.
Also adds an according entry to the XML examples for `moving_map`.

Use cases:

- My GPS compass seems to have some issues, so the moving map "jumps" around all the time (but I understand that this use case is very specific :wink:)
- The rotation reduces the map tiles' sharpness, I prefer sharper tiles at the cost of not having rotation.

Unfortunately, most of the tests (on current `main` code) failed for me, so I could not add tests or even verify that existing tests don't fail. I checked the `diff` images and it seems that a) my Roboto font differs slightly and b) OSM tiles are a bit different (not related to rotation, but names are at different positions, street and building borders are one pixel off, etc.).

Related to #16

PS: Thanks A LOT for this awesome project!