### PR TITLE
Add transparent overlay example to the docs

### DIFF
--- a/docs/bin/README.md
+++ b/docs/bin/README.md
@@ -46,6 +46,14 @@ venv/bin/gopro-dashboard.py --layout xml --layout-xml ~/layouts/my-layout.xml ~/
 venv/bin/gopro-dashboard.py --map-style tf-cycle --map-api-key my-api-key ~/layouts/my-layout.xml ~/gopro/GH020073.MP4 GH020073-dashboard.MP4
 ```
 
+*Create a transparent overlay without video, for using it in external software*
+
+You'll need to create an overlay profile (with alpha channel) - see [Create a movie with alpha channel](#create-a-movie-with-alpha-channel-using-only-gpx-file-without-any-video-at-all)
+
+```shell
+venv/bin/gopro-dashboard.py --generate overlay ~/gopro/GH020073.MP4 GH020073-dashboard.mov
+```
+
 *Create a movie, using GPU encoding and decoding*
 
 You'll need to create a profile - see [FFMPEG Profiles](#ffmpeg-profiles)


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #107

### Context

This makes to process to generate a **transparent** overlay without video clearer.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [x] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [MIT Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [ ] Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets
- [ ] Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` ) 
- [ ] Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.
- [ ] Check that pre-release tests work ( `make test-distribution` )
