### PR TITLE
document using hw h264 on macs

### DIFF
--- a/docs/bin/README.md
+++ b/docs/bin/README.md
@@ -152,6 +152,22 @@ then execute (NOTE: extension is `webm`)
 venv/bin/gopro-dashboard.py --use-gpx-only --gpx ~/Downloads/Morning_Ride.gpx --profile overlay --overlay-size 1920x1080 GH020073-dashboard.webm
 ```
 
+You could also use HW-accelerated `h264` on macOS ([more info on -q:v](https://trac.ffmpeg.org/wiki/HWAccelIntro#VideoToolbox)):
+```json
+{
+    "overlay-mac": {
+    "input": [],
+    "output": ["-vcodec", "h264_videotoolbox", "-q:v", "65"]
+  }
+}
+```
+
+
+then execute (**NOTE**: extension is `mp4`)
+```shell
+venv/bin/gopro-dashboard.py --use-gpx-only --gpx ~/Downloads/Morning_Ride.gpx --profile overlay-mac --overlay-size 1920x1080 GH020073-dashboard.mp4
+```
+
 ### Create a movie from GPX and video not created with GoPro
 
 This is currently quite hard to align things properly!


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #109 

### Context
<!--- Why is this useful? -->
Some trial & error is needed to use HW acceleration on Mac machines. This PR documents the required configuration to use HW acceleration.

I wasn't sure of the structure of the docs & English is not my first language, so I'd be happy to make any modifications.
<!--- Link to relevant issues or discussions here, please -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [x] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [MIT Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [ ] ~~Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets~~
- [ ] ~~Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` )~~
- [ ] ~~Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.~~
- [ ] ~~Check that pre-release tests work ( `make test-distribution` )~~


