### PR TITLE
Remove double 'kph' metric unit

### DIFF
--- a/docs/bin/README.md
+++ b/docs/bin/README.md
@@ -426,7 +426,7 @@ Units:
   Controlling Units
 
   --units-speed UNITS_SPEED
-                        Default unit for speed. Many units supported: mph, mps, kph, kph, knot, ... (default: mph)
+                        Default unit for speed. Many units supported: mph, mps, kph, knot, ... (default: mph)
   --units-altitude UNITS_ALTITUDE
                         Default unit for altitude. Many units supported: foot, mile, metre, meter, parsec,
                         angstrom, ... (default: metre)

--- a/gopro_overlay/arguments.py
+++ b/gopro_overlay/arguments.py
@@ -147,7 +147,7 @@ def gopro_dashboard_arguments(args=None):
     units = parser.add_argument_group("Units", "Controlling Units")
 
     units.add_argument("--units-speed", default="mph",
-                       help="Default unit for speed. Many units supported: mph, mps, kph, kph, knot, ...")
+                       help="Default unit for speed. Many units supported: mph, mps, kph, knot, ...")
     units.add_argument("--units-altitude", default="metre",
                        help="Default unit for altitude. Many units supported: foot, mile, metre, meter, parsec, angstrom, ...")
     units.add_argument("--units-distance", default="mile",

--- a/tests/layout/test_layout_conversions.py
+++ b/tests/layout/test_layout_conversions.py
@@ -70,7 +70,7 @@ def test_overriding_default_units():
 
 
 def test_various_speed_conversions_dont_blow_up():
-    for i in "mph, mps, kph, kph, knot".split(","):
+    for i in "mph, mps, kph, knot".split(","):
         Converters(speed_unit=i).converter("speed")(speed)
 
 


### PR DESCRIPTION
### Context
It seems the unit "kph" was specified twice. I've corrected this

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [x] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [GNU Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [x] Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets
- [x] Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` ) 
- [x] Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.
- [x] Check that pre-release tests work ( `make test-distribution` )
