### PR TITLE
Add "mp4-created" option to set video-time-start/end using mp4 metadata

### DIFF
--- a/bin/gopro-dashboard.py
+++ b/bin/gopro-dashboard.py
@@ -152,17 +152,18 @@ if __name__ == "__main__":
                         duration = recording.video.duration
 
                         fns = {
-                            "file-created": lambda f: f.ctime,
-                            "file-modified": lambda f: f.mtime,
-                            "file-accessed": lambda f: f.atime
+                            "file-created": lambda f: f.file.ctime,
+                            "file-modified": lambda f: f.file.mtime,
+                            "file-accessed": lambda f: f.file.atime,
+                            "mp4-created": lambda f: f.creationDateTime
                         }
 
                         if args.video_time_start:
-                            start_date = fns[args.video_time_start](recording.file)
+                            start_date = fns[args.video_time_start](recording)
                             end_date = start_date + duration.timedelta()
 
                         if args.video_time_end:
-                            start_date = fns[args.video_time_end](recording.file) - duration.timedelta()
+                            start_date = fns[args.video_time_end](recording) - duration.timedelta()
                             end_date = start_date + duration.timedelta()
 
                     else:

--- a/docs/bin/README.md
+++ b/docs/bin/README.md
@@ -332,8 +332,8 @@ usage: gopro-dashboard.py [-h] [--font FONT] [--privacy PRIVACY] [--generate {de
                           [--cache-dir CACHE_DIR] [--profile PROFILE] [--double-buffer] [--ffmpeg-dir FFMPEG_DIR]
                           [--load {ACCL,GRAV,CORI} [{ACCL,GRAV,CORI} ...]] [--gpx GPX]
                           [--gpx-merge {EXTEND,OVERWRITE}] [--use-gpx-only]
-                          [--video-time-start {file-created,file-modified,file-accessed}]
-                          [--video-time-end {file-created,file-modified,file-accessed}]
+                          [--video-time-start {file-created,file-modified,file-accessed,mp4-created}]
+                          [--video-time-end {file-created,file-modified,file-accessed,mp4-created}]
                           [--map-style {osm,tf-cycle,tf-transport,tf-landscape,tf-outdoors,tf-transport-dark,tf-spinal-map,tf-pioneer,tf-mobile-atlas,tf-neighbourhood,tf-atlas,geo-osm-carto,geo-osm-bright,geo-osm-bright-grey,geo-osm-bright-smooth,geo-klokantech-basic,geo-osm-liberty,geo-maptiler-3d,geo-toner,geo-toner-grey,geo-positron,geo-positron-blue,geo-positron-red,geo-dark-matter,geo-dark-matter-brown,geo-dark-matter-dark-grey,geo-dark-matter-dark-purple,geo-dark-matter-purple-roads,geo-dark-matter-yellow-roads,local}]
                           [--map-api-key MAP_API_KEY] [--layout {default,speed-awareness,xml}]
                           [--layout-xml LAYOUT_XML] [--exclude EXCLUDE [EXCLUDE ...]]
@@ -395,10 +395,10 @@ GPX Only:
 
   --use-gpx-only, --use-fit-only
                         Use only the GPX/FIT file - no GoPro location data (default: False)
-  --video-time-start {file-created,file-modified,file-accessed}
+  --video-time-start {file-created,file-modified,file-accessed,mp4-created}
                         Use file dates for aligning video and GPS information, only when --use-gpx-only -
                         EXPERIMENTAL! - may be changed/removed (default: None)
-  --video-time-end {file-created,file-modified,file-accessed}
+  --video-time-end {file-created,file-modified,file-accessed,mp4-created}
                         Use file dates for aligning video and GPS information, only when --use-gpx-only -
                         EXPERIMENTAL! - may be changed/removed (default: None)
 

--- a/gopro_overlay/arguments.py
+++ b/gopro_overlay/arguments.py
@@ -124,9 +124,9 @@ def gopro_dashboard_arguments(args=None):
 
     only.add_argument("--use-gpx-only", "--use-fit-only", action="store_true",
                       help="Use only the GPX/FIT file - no GoPro location data")
-    only.add_argument("--video-time-start", choices=["file-created", "file-modified", "file-accessed"],
+    only.add_argument("--video-time-start", choices=["file-created", "file-modified", "file-accessed", "mp4-created"],
                       help="Use file dates for aligning video and GPS information, only when --use-gpx-only - EXPERIMENTAL! - may be changed/removed")
-    only.add_argument("--video-time-end", choices=["file-created", "file-modified", "file-accessed"],
+    only.add_argument("--video-time-end", choices=["file-created", "file-modified", "file-accessed", "mp4-created"],
                       help="Use file dates for aligning video and GPS information, only when --use-gpx-only - EXPERIMENTAL! - may be changed/removed")
 
     maps = parser.add_argument_group("Mapping", "Display of Maps")

--- a/gopro_overlay/ffmpeg_gopro.py
+++ b/gopro_overlay/ffmpeg_gopro.py
@@ -72,6 +72,7 @@ class FFMPEGGoPro:
                 "-hide_banner",
                 "-print_format", "json",
                 "-show_streams",
+                "-show_entries", "stream_tags:format_tags",
                 filepath
             ]
         ).stdout)
@@ -127,13 +128,20 @@ class FFMPEGGoPro:
         else:
             data_stream = None
 
+        creationDateTime = None
+        try:
+            creationDateTime = datetime.datetime.fromisoformat(ffprobe_json["format"]["tags"]["creation_time"])
+        except Exception:
+            pass
+
         return GoproRecording(
             ffmpeg=self.exe,
             location=filepath,
             file=filestat(filepath, stat=stat),
             audio=audio_stream,
             video=video_stream,
-            data=data_stream
+            data=data_stream,
+            creationDateTime=creationDateTime
         )
 
     def load_frame(self, filepath: Path, at_time: Timeunit) -> Optional[bytes]:
@@ -201,6 +209,7 @@ class GoproRecording:
     audio: Optional[AudioStream]
     video: VideoStream
     data: Optional[DataStream]
+    creationDateTime: datetime.datetime
 
     def load_data(self) -> bytes:
         track = self.data.stream


### PR DESCRIPTION

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [X] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [GNU Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [ ] Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets
- [ ] Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` ) 
- [ ] Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.
- [ ] Check that pre-release tests work ( `make test-distribution` )
