### PR TITLE
Add "full-timeseries-journey" option to use the full timeseries for the journey

### DIFF
--- a/bin/gopro-dashboard.py
+++ b/bin/gopro-dashboard.py
@@ -32,6 +32,7 @@ from gopro_overlay.point import Point
 from gopro_overlay.privacy import PrivacyZone, NoPrivacyZone
 from gopro_overlay.progresstrack import ProgressBarProgress
 from gopro_overlay.timeunits import timeunits, Timeunit
+from gopro_overlay.timeseries import Timeseries
 from gopro_overlay.timing import PoorTimer, Timers
 from gopro_overlay.units import units
 from gopro_overlay.widgets.profile import WidgetProfiler
@@ -50,7 +51,8 @@ def accepter_from_args(include, exclude):
 
 
 def create_desired_layout(dimensions, layout, layout_xml: Path, include, exclude, renderer, timeseries, font,
-                          privacy_zone, profiler, converters: Converters):
+                          privacy_zone, profiler, converters: Converters,
+                          fulltimeseries: Timeseries = None):
     accepter = accepter_from_args(include, exclude)
 
     if layout_xml:
@@ -61,7 +63,7 @@ def create_desired_layout(dimensions, layout, layout_xml: Path, include, exclude
         try:
             return layout_from_xml(
                 load_xml_layout(resource_name), renderer, timeseries, font, privacy_zone, include=accepter,
-                decorator=profiler, converters=converters
+                decorator=profiler, converters=converters, fulltimeseries=fulltimeseries
             )
         except FileNotFoundError:
             raise IOError(f"Unable to locate bundled layout resource: {resource_name}. "
@@ -72,7 +74,7 @@ def create_desired_layout(dimensions, layout, layout_xml: Path, include, exclude
     elif layout == "xml":
         return layout_from_xml(
             load_xml_layout(layout_xml), renderer, timeseries, font, privacy_zone, include=accepter,
-            decorator=profiler, converters=converters
+            decorator=profiler, converters=converters, fulltimeseries=fulltimeseries
         )
     else:
         raise ValueError(f"Unsupported layout {args.layout_creator}")
@@ -357,7 +359,8 @@ if __name__ == "__main__":
                     font=font,
                     privacy_zone=privacy_zone,
                     profiler=profiler,
-                    converters=unit_converters
+                    converters=unit_converters,
+                    fulltimeseries=fit_or_gpx_timeseries if args.full_timeseries_journey else None
                 )
 
                 overlay = Overlay(framemeta=frame_meta, create_widgets=layout_creator)

--- a/gopro_overlay/arguments.py
+++ b/gopro_overlay/arguments.py
@@ -124,6 +124,8 @@ def gopro_dashboard_arguments(args=None):
 
     only.add_argument("--use-gpx-only", "--use-fit-only", action="store_true",
                       help="Use only the GPX/FIT file - no GoPro location data")
+    only.add_argument("--full-timeseries-journey", action="store_true",
+                      help="Use the full timeseries for the journey")
     only.add_argument("--video-time-start", choices=["file-created", "file-modified", "file-accessed"],
                       help="Use file dates for aligning video and GPS information, only when --use-gpx-only - EXPERIMENTAL! - may be changed/removed")
     only.add_argument("--video-time-end", choices=["file-created", "file-modified", "file-accessed"],

--- a/gopro_overlay/layout_xml.py
+++ b/gopro_overlay/layout_xml.py
@@ -105,7 +105,8 @@ class Converters:
 
 
 def layout_from_xml(xml, renderer, framemeta, font, privacy, include=lambda name: True,
-                    decorator: Optional[WidgetProfiler] = None, converters: Converters = Converters()):
+                    decorator: Optional[WidgetProfiler] = None, converters: Converters = Converters(),
+                    fulltimeseries = None):
     root = ET.fromstring(xml)
 
     fonts = {}
@@ -121,6 +122,7 @@ def layout_from_xml(xml, renderer, framemeta, font, privacy, include=lambda name
         renderer=renderer,
         framemeta=framemeta,
         converters=converters,
+        fulltimeseries=fulltimeseries
     )
 
     def name_of(element):
@@ -389,12 +391,13 @@ class FloatRange:
 
 class Widgets:
 
-    def __init__(self, font, privacy, renderer, framemeta, converters):
+    def __init__(self, font, privacy, renderer, framemeta, converters, fulltimeseries = None):
         self.framemeta = framemeta
         self.renderer = renderer
         self.privacy = privacy
         self.font = font
         self.converters = converters
+        self.fulltimeseries = fulltimeseries
 
     def _font(self, element, name, d):
         return self.font(iattrib(element, name, d=d, r=range(1, 2000)))
@@ -494,6 +497,7 @@ class Widgets:
             privacy_zone=self.privacy,
             renderer=self.renderer,
             timeseries=self.framemeta,
+            fulltimeseries=self.fulltimeseries,
             size=iattrib(element, "size", d=256),
             corner_radius=iattrib(element, "corner_radius", 0),
             opacity=fattrib(element, "opacity", 0.7, r=FloatRange(0.0, 1.0))

--- a/gopro_overlay/widgets/map.py
+++ b/gopro_overlay/widgets/map.py
@@ -83,8 +83,9 @@ class MaybeRoundedBorder:
 
 class JourneyMap(Widget):
     def __init__(self, timeseries, at, location, renderer, size=256, corner_radius=None, opacity=0.7,
-                 privacy_zone=NoPrivacyZone()):
+                 privacy_zone=NoPrivacyZone(), fulltimeseries=None):
         self.timeseries = timeseries
+        self.fulltimeseries = fulltimeseries
         self.privacy_zone = privacy_zone
         self.at = at
         self.location = location
@@ -98,7 +99,10 @@ class JourneyMap(Widget):
         if self.map is None:
             journey = Journey()
 
-            self.timeseries.process(journey.accept)
+            if self.fulltimeseries is None:
+                self.timeseries.process(journey.accept)
+            else:
+                self.fulltimeseries.process(journey.accept)
 
             bbox = journey.bounding_box
             self.map = geotiler.Map(extent=(bbox.min.lon, bbox.min.lat, bbox.max.lon, bbox.max.lat),


### PR DESCRIPTION
Used for when you have video clips from a longer gpx track and so want to display the entire journey still

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [X] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Make sure all contributed code can be distributed under the terms of the [GNU Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [ ] Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets
- [ ] Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` ) 
- [ ] Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.
- [ ] Check that pre-release tests work ( `make test-distribution` )
