### PR TITLE
Fix typo in bbox calculation

### DIFF
--- a/gopro_overlay/widgets/text.py
+++ b/gopro_overlay/widgets/text.py
@@ -43,7 +43,7 @@ class CachingText(Widget):
             if x0 < 0:
                 x1 = x1 + abs(x0)
             if y0 < 0:
-                y1 = y1 + abs(x0)
+                y1 = y1 + abs(y0)
 
             backing_image = Image.new(mode="RGBA", size=(x1, y1))
             backing_draw = ImageDraw.Draw(backing_image)


### PR DESCRIPTION
This is a typo. 
When using anchor="mm", Pillow calculates the size of the bounding box related to the anchor. Pillow can return a bbox with negative y0.

The cache code, due to the type, computes the backing image dimensions incorrectly and can clip text.

That can make centered text look offset or clipped, which is why it can seem like a value “isn’t showing.”

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why is this useful? -->
<!--- Link to relevant issues or discussions here, please -->

### Contributor Checklist
- [x] This is not generated by an "AI" tool
- [ ] [Review Contribution Guidelines](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/CONTRIBUTING.md) 
- [x] Agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Make sure all contributed code can be distributed under the terms of the [GNU Licence](https://github.com/time4tea/gopro-dashboard-overlay/blob/main/LICENSE.md)
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by maintainers if required.
- [ ] Unit tests created/updated (under `tests`) to verify logic, and approval tests for UI Widgets
- [ ] Update Examples - Under `build-scripts/examples`, and regenerate examples docs if required ( `make doc-examples` ) 
- [ ] Ensure that tests pass locally - this can be tricky for approval tests with maps or text though.
- [ ] Check that pre-release tests work ( `make test-distribution` )
